### PR TITLE
Update SimpleHostRoutingFilter.java

### DIFF
--- a/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
+++ b/spring-cloud-netflix-core/src/main/java/org/springframework/cloud/netflix/zuul/filters/route/SimpleHostRoutingFilter.java
@@ -258,7 +258,7 @@ public class SimpleHostRoutingFilter extends ZuulFilter {
 		HttpRequest httpRequest;
 		int contentLength = request.getContentLength();
 		InputStreamEntity entity = new InputStreamEntity(requestEntity, contentLength,
-				ContentType.create(request.getContentType()));
+				(request.getContentType() == null ? null : ContentType.create(request.getContentType())));
 		switch (verb.toUpperCase()) {
 		case "POST":
 			HttpPost httpPost = new HttpPost(uri + this.helper.getQueryString(params));


### PR DESCRIPTION
Check if Content-Type on the request object is null before creating a ContentType object. 

Fixes gh-1037.